### PR TITLE
Feature/simplify start

### DIFF
--- a/Editor/MoralisWeb3SdkEditor.cs
+++ b/Editor/MoralisWeb3SdkEditor.cs
@@ -51,6 +51,8 @@ namespace MoralisUnity.Editor
             }
 
             win.isSetupWizard = true;
+            win.minSize = new Vector2(750, 500);
+            win.maxSize = new Vector2(750, 500);
             win.Show();
         }
 

--- a/Runtime/Core/MoralisController.cs
+++ b/Runtime/Core/MoralisController.cs
@@ -28,7 +28,6 @@
  */
 
 using Cysharp.Threading.Tasks;
-using MoralisUnity.Platform;
 using UnityEngine;
 using WalletConnectSharp.Unity;
 using WalletConnectSharp.Core.Models;
@@ -43,14 +42,6 @@ namespace MoralisUnity
         {
             if (!Moralis.Initialized)
             {
-                HostManifestData hostManifestData = new HostManifestData()
-                {
-                    Version = MoralisSettings.MoralisData.ApplicationVersion,
-                    Identifier = MoralisSettings.MoralisData.ApplicationName,
-                    Name = MoralisSettings.MoralisData.ApplicationName,
-                    ShortVersion = MoralisSettings.MoralisData.ApplicationVersion
-                };
-
                 ClientMeta clientMeta = new ClientMeta()
                 {
                     Name = MoralisSettings.MoralisData.ApplicationName,
@@ -61,9 +52,18 @@ namespace MoralisUnity
 
                 walletConnect.AppData = clientMeta;
 
-                // Initialize and register the Moralis, Moralis Web3Api and NEthereum Web3 clients
-                await Moralis.Start(MoralisSettings.MoralisData.ServerUri, MoralisSettings.MoralisData.ApplicationId, hostManifestData, clientMeta);
+                // Initialize and register the Moralis, Moralis Web3Api and
+                // NEthereum Web3 clients
+                Moralis.Start();
+
+                // Trigger get user so that if user has been persisted, it is available.
+                await Moralis.GetUserAsync();
             }
+        }
+
+        public async void Start()
+        {
+            await Initialize();
         }
     }
 }

--- a/Runtime/Core/MoralisUnity.cs
+++ b/Runtime/Core/MoralisUnity.cs
@@ -64,7 +64,6 @@ namespace MoralisUnity
         /// </summary>
         public static bool Initialized { get; set; }
 
-        //public static ChainList ChainList;
         public static ChainEntry CurrentChain;
 
 #if UNITY_WEBGL

--- a/Runtime/Core/MoralisUnity.cs
+++ b/Runtime/Core/MoralisUnity.cs
@@ -48,6 +48,8 @@ using WalletConnectSharp.Core;
 using WalletConnectSharp.Core.Models;
 using WalletConnectSharp.NEthereum;
 using WalletConnectSharp.Unity;
+using MoralisUnity.SolanaApi.Interfaces;
+using MoralisUnity.Platform.Queries;
 
 namespace MoralisUnity
 {
@@ -62,7 +64,8 @@ namespace MoralisUnity
         /// </summary>
         public static bool Initialized { get; set; }
 
-        public static ChainList ChainList;
+        //public static ChainList ChainList;
+        public static ChainEntry CurrentChain;
 
 #if UNITY_WEBGL
         /// <summary>
@@ -87,7 +90,34 @@ namespace MoralisUnity
         private static MoralisUser user;
 
         public static IWeb3Api Web3Api;
-        
+
+        public static ISolanaApi SolanaApi;
+
+        public static void Start()
+        {
+            if (!Initialized)
+            {
+                HostManifestData hostManifestData = new HostManifestData()
+                {
+                    Version = MoralisSettings.MoralisData.ApplicationVersion,
+                    Identifier = MoralisSettings.MoralisData.ApplicationName,
+                    Name = MoralisSettings.MoralisData.ApplicationName,
+                    ShortVersion = MoralisSettings.MoralisData.ApplicationVersion
+                };
+
+                ClientMeta clientMeta = new ClientMeta()
+                {
+                    Name = MoralisSettings.MoralisData.ApplicationName,
+                    Description = MoralisSettings.MoralisData.ApplicationDescription,
+                    Icons = new[] { MoralisSettings.MoralisData.ApplicationIconUri },
+                    URL = MoralisSettings.MoralisData.ApplicationUrl
+                };
+
+                // Initialize and register the Moralis, Moralis Web3Api and NEthereum Web3 clients
+                Moralis.Start(MoralisSettings.MoralisData.ServerUri, MoralisSettings.MoralisData.ApplicationId, hostManifestData, clientMeta);
+            }
+        }
+
         /// <summary>
         /// Initializes the connection to a Moralis server.
         /// </summary>
@@ -96,7 +126,8 @@ namespace MoralisUnity
         /// <param name="hostData"></param>
         /// <param name="clientMeta"></param>
         /// <param name="web3ApiKey"></param>
-        public static async UniTask Start(string serverUri, string applicationId, HostManifestData hostData = null, ClientMeta clientMeta = null, string web3ApiKey = null)
+        //public static async UniTask Start(string serverUri, string applicationId, HostManifestData hostData = null, ClientMeta clientMeta = null, string web3ApiKey = null)
+       public static void Start(string serverUri, string applicationId, HostManifestData hostData = null, ClientMeta clientMeta = null, string web3ApiKey = null)
         {
             // Application Id is requried.
             if (string.IsNullOrEmpty(applicationId))
@@ -169,9 +200,11 @@ namespace MoralisUnity
             else
             {
                 Web3Api = client.Web3Api;
+                SolanaApi = client.SolanaApi;
+                
                 Initialized = true;
                 Debug.Log("Connected to Moralis!");
-                user = await client.GetCurrentUserAsync();
+                //user = await client.GetCurrentUserAsync();
             }
         }
 
@@ -199,12 +232,7 @@ namespace MoralisUnity
         /// <returns>MoralisUser</returns>
         public static async UniTask<MoralisUser> GetUser()
         {
-            if (user == null)
-            {
-                user = await client.GetCurrentUser();
-            }
-
-            return user;
+            return await GetUserAsync();
         }
 
         /// <summary>
@@ -235,10 +263,18 @@ namespace MoralisUnity
         /// EXAMPLE: { { "id", address }, { "signature", response }, { "data", "Moralis Authentication" } }
         /// </summary>
         /// <param name="authData"></param>
+        /// <param name="chainId">Chain Id returned by authenticating Wallet</param>
         /// <returns></returns>
-        public static async UniTask<MoralisUser> LogInAsync(IDictionary<string, object> authData)
+        public static async UniTask<MoralisUser> LogInAsync(IDictionary<string, object> authData, int chainId = -1)
         {
-            return await client.LogInAsync(authData, CancellationToken.None);
+            if (chainId >= 0)
+            {
+                CurrentChain = SupportedEvmChains.FromChainList(chainId);
+            }
+
+            user = await client.LogInAsync(authData, CancellationToken.None);
+
+            return user;
         }
 
         /// <summary>
@@ -247,9 +283,11 @@ namespace MoralisUnity
         /// <param name="username">username / Email</param>
         /// <param name="password">user password</param>
         /// <returns>MoralisUser</returns>
-        public static UniTask<MoralisUser> LogInAsync(string username, string password)
+        public static async UniTask<MoralisUser> LogInAsync(string username, string password)
         {
-            return client.UserService.LogInAsync(username, password, client.ServiceHub);
+            user = await client.UserService.LogInAsync(username, password, client.ServiceHub);
+
+            return user;
         }
 
         /// <summary>
@@ -258,8 +296,100 @@ namespace MoralisUnity
         /// <returns></returns>
         public static UniTask LogOutAsync()
         {
+            user = null;
             return client.LogOutAsync();
         }
+
+        #region MoralisClient and other objects direct calls
+        /// <summary>
+        /// Shortcut to MoralisClient.ApplicationId
+        /// </summary>
+        public static string ApplicationId 
+        {
+            get
+            {
+                return client.ApplicationId;
+            }
+        }
+
+        /// <summary>
+        /// Shortcut to MoralisClient.Cloud 
+        /// </summary>
+        /// <returns></returns>
+        public static MoralisCloud<MoralisUser> Cloud
+        {
+            get
+            {
+                return client.Cloud;
+            }
+        }
+        /// <summary>
+        /// Shortcut to MoralisClient.BuildAndQuery<T> 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="queries"></param>
+        /// <returns></returns>
+        public static MoralisQuery<T> BuildAndQuery<T>(MoralisQuery<T> source, params MoralisQuery<T>[] queries) where T : MoralisObject
+        {
+            return client.BuildAndQuery<T>(source, queries);
+        }
+
+        /// <summary>
+        /// Shortcut to MoralisClient.BuildNorQuery<T> 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="queries"></param>
+        /// <returns></returns>
+        public static MoralisQuery<T> BuildNorQuery<T>(MoralisQuery<T> source, params MoralisQuery<T>[] queries) where T : MoralisObject
+        {
+            return client.BuildNorQuery<T>(source, queries);
+        }
+
+        /// <summary>
+        /// Shortcut to MoralisClient.BuildOrQuery<T> 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="queries"></param>
+        /// <returns></returns>
+        public static MoralisQuery<T> BuildOrQuery<T>(MoralisQuery<T> source, params MoralisQuery<T>[] queries) where T : MoralisObject
+        {
+            return client.BuildOrQuery<T>(source, queries);
+        }
+
+        /// <summary>
+        /// Shortcut to MoralisClient.Create<T> 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public static T Create<T>(object[] parameters = null) where T : MoralisObject
+        {
+            return client.Create<T>(parameters);
+        }
+
+        /// <summary>
+        /// Shortcut to MoralisClient.DeleteAsync
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="target"></param>
+        public static async void DeleteAsync<T>(T target) where T : MoralisObject
+        {
+            await client.DeleteAsync(target);
+        }
+
+        /// <summary>
+        /// Shortcut to MoralisClient.Query
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static UniTask<MoralisQuery<T>> Query<T>() where T : MoralisObject
+        {
+            return client.Query<T>();
+        }
+        #endregion
 
         public static List<ChainEntry> SupportedChains => SupportedEvmChains.SupportedChains;
         

--- a/Runtime/Core/MoralisUnity.cs
+++ b/Runtime/Core/MoralisUnity.cs
@@ -89,9 +89,9 @@ namespace MoralisUnity
         // keep a local copy to save some cycles.
         private static MoralisUser user;
 
-        public static IWeb3Api Web3Api;
+        private static IWeb3Api Web3ApiClient;
 
-        public static ISolanaApi SolanaApi;
+        private static ISolanaApi SolanaApiClient;
 
         public static void Start()
         {
@@ -222,6 +222,7 @@ namespace MoralisUnity
         /// <returns></returns>
         public static MoralisClient GetClient()
         {
+            EnsureClient();
             return client;
         }
 
@@ -267,6 +268,8 @@ namespace MoralisUnity
         /// <returns></returns>
         public static async UniTask<MoralisUser> LogInAsync(IDictionary<string, object> authData, int chainId = -1)
         {
+            EnsureClient();
+
             if (chainId >= 0)
             {
                 CurrentChain = SupportedEvmChains.FromChainList(chainId);
@@ -285,6 +288,8 @@ namespace MoralisUnity
         /// <returns>MoralisUser</returns>
         public static async UniTask<MoralisUser> LogInAsync(string username, string password)
         {
+            EnsureClient();
+
             user = await client.UserService.LogInAsync(username, password, client.ServiceHub);
 
             return user;
@@ -320,9 +325,12 @@ namespace MoralisUnity
         {
             get
             {
+                EnsureClient();
+
                 return client.Cloud;
             }
         }
+
         /// <summary>
         /// Shortcut to MoralisClient.BuildAndQuery<T> 
         /// </summary>
@@ -332,6 +340,8 @@ namespace MoralisUnity
         /// <returns></returns>
         public static MoralisQuery<T> BuildAndQuery<T>(MoralisQuery<T> source, params MoralisQuery<T>[] queries) where T : MoralisObject
         {
+            EnsureClient();
+
             return client.BuildAndQuery<T>(source, queries);
         }
 
@@ -344,6 +354,8 @@ namespace MoralisUnity
         /// <returns></returns>
         public static MoralisQuery<T> BuildNorQuery<T>(MoralisQuery<T> source, params MoralisQuery<T>[] queries) where T : MoralisObject
         {
+            EnsureClient();
+
             return client.BuildNorQuery<T>(source, queries);
         }
 
@@ -356,6 +368,8 @@ namespace MoralisUnity
         /// <returns></returns>
         public static MoralisQuery<T> BuildOrQuery<T>(MoralisQuery<T> source, params MoralisQuery<T>[] queries) where T : MoralisObject
         {
+            EnsureClient();
+
             return client.BuildOrQuery<T>(source, queries);
         }
 
@@ -367,6 +381,8 @@ namespace MoralisUnity
         /// <returns></returns>
         public static T Create<T>(object[] parameters = null) where T : MoralisObject
         {
+            EnsureClient();
+
             return client.Create<T>(parameters);
         }
 
@@ -377,6 +393,8 @@ namespace MoralisUnity
         /// <param name="target"></param>
         public static async void DeleteAsync<T>(T target) where T : MoralisObject
         {
+            EnsureClient();
+
             await client.DeleteAsync(target);
         }
 
@@ -387,7 +405,41 @@ namespace MoralisUnity
         /// <returns></returns>
         public static UniTask<MoralisQuery<T>> Query<T>() where T : MoralisObject
         {
+            EnsureClient();
+
             return client.Query<T>();
+        }
+
+        /// <summary>
+        /// Web3Api Client
+        /// </summary>
+        public static IWeb3Api Web3Api
+        {
+            get
+            {
+                EnsureClient();
+                return Web3ApiClient;
+            }
+            set
+            {
+                Web3ApiClient = value;
+            }
+        }
+
+        /// <summary>
+        /// SolanApi Client
+        /// </summary>
+        public static ISolanaApi SolanaApi
+        {
+            get
+            {
+                EnsureClient();
+                return SolanaApiClient;
+            }
+            set
+            {
+                SolanaApiClient = value;
+            }
         }
         #endregion
 
@@ -719,5 +771,13 @@ namespace MoralisUnity
             return result;
         }
 #endif
+
+        private static void EnsureClient()
+        {
+            if (client == null)
+            {
+                Start();
+            }
+        }
     }
 }

--- a/Runtime/Core/MoralisUnity.cs
+++ b/Runtime/Core/MoralisUnity.cs
@@ -126,8 +126,7 @@ namespace MoralisUnity
         /// <param name="hostData"></param>
         /// <param name="clientMeta"></param>
         /// <param name="web3ApiKey"></param>
-        //public static async UniTask Start(string serverUri, string applicationId, HostManifestData hostData = null, ClientMeta clientMeta = null, string web3ApiKey = null)
-       public static void Start(string serverUri, string applicationId, HostManifestData hostData = null, ClientMeta clientMeta = null, string web3ApiKey = null)
+        public static void Start(string serverUri, string applicationId, HostManifestData hostData = null, ClientMeta clientMeta = null, string web3ApiKey = null)
         {
             // Application Id is requried.
             if (string.IsNullOrEmpty(applicationId))
@@ -204,7 +203,6 @@ namespace MoralisUnity
                 
                 Initialized = true;
                 Debug.Log("Connected to Moralis!");
-                //user = await client.GetCurrentUserAsync();
             }
         }
 

--- a/Samples~/MoralisDemo/Scripts/MainMenuScript.cs
+++ b/Samples~/MoralisDemo/Scripts/MainMenuScript.cs
@@ -70,17 +70,6 @@ namespace MoralisUnity.MoralisDemo.Scripts
             androidMenu.SetActive(false);
             iosMenu.SetActive(false);
 
-            // await MoralisUnity.Initialize(MoralisApplicationId, MoralisServerURI, hostManifestData);
-            if (moralisController != null && moralisController)
-            {
-                await moralisController.Initialize();
-            }
-            else
-            {
-                // Moralis values not set or initialized.
-                Debug.LogError("The MoralisWeb3 has not been set up, please check you MoralisController in the scene.");
-            }
-
             // If user is not logged in show the "Authenticate" button.
             if (!Moralis.IsLoggedIn())
             {
@@ -176,11 +165,11 @@ namespace MoralisUnity.MoralisDemo.Scripts
             else
             {
                 string address = Web3GL.Account().ToLower();
-                string appId = Moralis.GetClient().ApplicationId;
+                string appId = Moralis.ApplicationId;
                 long serverTime = 0;
 
                 // Retrieve server time from Moralis Server for message signature
-                Dictionary<string, object> serverTimeResponse = await Moralis.GetClient().Cloud
+                Dictionary<string, object> serverTimeResponse = await Moralis.Cloud
                     .RunAsync<Dictionary<string, object>>("getServerTime", new Dictionary<string, object>());
 
                 if (serverTimeResponse == null || !serverTimeResponse.ContainsKey("dateTime") ||
@@ -238,11 +227,11 @@ namespace MoralisUnity.MoralisDemo.Scripts
 
             // Extract wallet address from the Wallet Connect Session data object.
             string address = data.accounts[0].ToLower();
-            string appId = Moralis.GetClient().ApplicationId;
+            string appId = Moralis.ApplicationId;
             long serverTime = 0;
 
             // Retrieve server time from Moralis Server for message signature
-            Dictionary<string, object> serverTimeResponse = await Moralis.GetClient().Cloud
+            Dictionary<string, object> serverTimeResponse = await Moralis.Cloud
                 .RunAsync<Dictionary<string, object>>("getServerTime", new Dictionary<string, object>());
 
             if (serverTimeResponse == null || !serverTimeResponse.ContainsKey("dateTime") ||
@@ -262,7 +251,7 @@ namespace MoralisUnity.MoralisDemo.Scripts
                 { { "id", address }, { "signature", response }, { "data", signMessage } };
 
             // Attempt to login user.
-            MoralisUser user = await Moralis.LogInAsync(authData);
+            MoralisUser user = await Moralis.LogInAsync(authData, data.chainId.Value);
 
             signaturePending = false;
 

--- a/Samples~/MoralisDemo/Scripts/MainMenuScript.cs
+++ b/Samples~/MoralisDemo/Scripts/MainMenuScript.cs
@@ -45,7 +45,6 @@ namespace MoralisUnity.MoralisDemo.Scripts
     /// </summary>
     public class MainMenuScript : MonoBehaviour
     {
-        public MoralisController moralisController;
         public GameObject authenticationButton;
         public GameObject logoutButton;
         public WalletConnect walletConnect;

--- a/Samples~/MoralisDemo/Scripts/MainMenuScript.cs
+++ b/Samples~/MoralisDemo/Scripts/MainMenuScript.cs
@@ -61,7 +61,7 @@ namespace MoralisUnity.MoralisDemo.Scripts
             walletConnect.CLearSession();
         }
 
-        async void Start()
+        void Start()
         {
             menuBackground = (Image)gameObject.GetComponent(typeof(Image));
 


### PR DESCRIPTION
- Ensure SetupWizard view size is set
- Update Moralis Controller so that it automatically starts Moralis Client at startup based on MoralisSettings
- Remove MoralisController reference from MainMenuScript
- Create static wrappers for MoralisClient so that these can be called directly without GetClient()
- Enable Moralis.Start to be called without parameters and non-async.
- Ensure that when Moralis methods are called that require MoralisClient, that method starts MoralisClient automatically.
