### PR TITLE
Updated AuthKit to listen LESS to WalletConnect

### DIFF
--- a/Runtime/Kits/AuthenticationKit/Scripts/Runtime/AuthenticationKit.cs
+++ b/Runtime/Kits/AuthenticationKit/Scripts/Runtime/AuthenticationKit.cs
@@ -19,7 +19,7 @@ namespace MoralisUnity.Kits.AuthenticationKit
     {
         //  Properties ------------------------------------
         public AuthenticationKitController Controller { get { return _authenticationKitController;}} 
-        public bool WillAutoInitializeOnStart { get { return _willAutoInitializeOnStart;}}
+        public bool WillInitializeOnStart { get { return _willInitializeOnStart;}}
         
         
         //  Fields ----------------------------------------
@@ -28,13 +28,13 @@ namespace MoralisUnity.Kits.AuthenticationKit
         
         [Header("Settings")] 
         [SerializeField] 
-        private bool _willAutoInitializeOnStart = true;
+        private bool _willInitializeOnStart = true;
 
                 
         //  Unity Methods ---------------------------------
         protected async void Start()
         {
-            if (_willAutoInitializeOnStart)
+            if (_willInitializeOnStart)
             {
                 await Controller.InitializeAsync();  
             }

--- a/Runtime/Kits/AuthenticationKit/Scripts/Runtime/AuthenticationKitController.cs
+++ b/Runtime/Kits/AuthenticationKit/Scripts/Runtime/AuthenticationKitController.cs
@@ -69,7 +69,6 @@ namespace MoralisUnity.Kits.AuthenticationKit
 
         
         //  Fields ----------------------------------------
-        [Header("3rd Party")]
         [SerializeField] 
         private WalletConnect _walletConnect;
         
@@ -110,10 +109,6 @@ namespace MoralisUnity.Kits.AuthenticationKit
             
             State = AuthenticationKitState.Initialized;
             
-            // Safely, listen
-            _walletConnect.ConnectedEventSession.RemoveListener(WalletConnect_OnConnectedEventSession);
-            _walletConnect.ConnectedEventSession.AddListener(WalletConnect_OnConnectedEventSession);
-            
             // If user is not logged in show the "Authenticate" button.
             if (Moralis.IsLoggedIn())
             {
@@ -137,10 +132,6 @@ namespace MoralisUnity.Kits.AuthenticationKit
         /// </summary>
         public void Connect()
         {
-            if (State != AuthenticationKitState.Initialized)
-            {
-                throw new UnexpectedStateException(State, AuthenticationKitState.Initialized);
-            }
             State = AuthenticationKitState.Connecting;
         }
 
@@ -277,15 +268,31 @@ namespace MoralisUnity.Kits.AuthenticationKit
         //  Event Handlers --------------------------------
         private async void StateObservable_OnValueChanged( AuthenticationKitState value)
         {
+            // Order matters here.
+            
             // 1. Broadcast
             OnStateChanged.Invoke(_stateObservable.Value);
             
             // 2. Step the state. Rarely.
             switch (_stateObservable.Value)
             {
-                case AuthenticationKitState.Disconnected:
-	                await InitializeAsync();
+                case AuthenticationKitState.Connecting:
+                    
+                    // Safely observe
+                    _walletConnect.ConnectedEventSession.RemoveListener(WalletConnect_OnConnectedEventSession);
+                    _walletConnect.ConnectedEventSession.AddListener(WalletConnect_OnConnectedEventSession);
                     break;
+                
+                case AuthenticationKitState.Connected:
+                    
+                    // Unobserve
+                    _walletConnect.ConnectedEventSession.RemoveListener(WalletConnect_OnConnectedEventSession);
+                    break;
+                
+                case AuthenticationKitState.Disconnected:
+                    await InitializeAsync();
+                    break;
+                
                 default:
                     break;   
             }
@@ -300,6 +307,8 @@ namespace MoralisUnity.Kits.AuthenticationKit
         /// <returns></returns>
         public async void WalletConnect_OnConnectedEventSession(WCSessionData wcSessionData)
         {
+            //Debug.Log($"WalletConnect_OnConnectedEventSession() wcSessionData = {wcSessionData}");
+                
             State = AuthenticationKitState.Signing;
             
             // Extract wallet address from the Wallet Connect Session data object.

--- a/Runtime/Kits/AuthenticationKit/Scripts/Runtime/AuthenticationKitView.cs
+++ b/Runtime/Kits/AuthenticationKit/Scripts/Runtime/AuthenticationKitView.cs
@@ -154,7 +154,7 @@ namespace MoralisUnity.Kits.AuthenticationKit
         }
         
         
-        private async void AuthenticationKit_OnStateChanged(AuthenticationKitState authenticationKitState)
+        private void AuthenticationKit_OnStateChanged(AuthenticationKitState authenticationKitState)
         {
             switch (authenticationKitState)
             {

--- a/Samples~/Moralis AuthenticationKit Example/Scenes/Example_AuthenticationKit.unity
+++ b/Samples~/Moralis AuthenticationKit Example/Scenes/Example_AuthenticationKit.unity
@@ -292,6 +292,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _authenticationKit: {fileID: 1727539693}
+  _walletConnect: {fileID: 1723419863}
 --- !u!1 &1710304813
 GameObject:
   m_ObjectHideFlags: 0
@@ -375,6 +376,17 @@ Transform:
   m_Father: {fileID: 976913286}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1723419863 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5302162188967417741, guid: a41feed31bcc36541a7a9505212ddc63, type: 3}
+  m_PrefabInstance: {fileID: 1727539692}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 801bffbf4c62cc244b55ea230d19649d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1727539692
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Samples~/Moralis AuthenticationKit Example/Scripts/Example_AuthenticationKit.cs
+++ b/Samples~/Moralis AuthenticationKit Example/Scripts/Example_AuthenticationKit.cs
@@ -14,13 +14,11 @@ namespace MoralisUnity.Examples.AuthenticationKitDemo
 	/// </summary>
 	public class Example_AuthenticationKit : MonoBehaviour
 	{
-		//  Properties ------------------------------------
-
 		
 		//  Fields ----------------------------------------
 		[SerializeField] 
 		private AuthenticationKit _authenticationKit = null;
-		
+
 		
 		//  Unity Methods ---------------------------------
 		protected void Awake()
@@ -31,23 +29,24 @@ namespace MoralisUnity.Examples.AuthenticationKitDemo
 		
 		protected void Start()
 		{
-			// Optionally, The demo itself can trigger init
-			// For advanced use cases
-			if (!_authenticationKit.WillAutoInitializeOnStart)
+			// Optionally, The Example_AuthenticationKit can trigger
+			// initialization for advanced use cases
+			if (!_authenticationKit.WillInitializeOnStart)
 			{
 				_authenticationKit.Controller.InitializeAsync();
 			}
 		}
+
 		
 		//  Event Handlers --------------------------------
-		private void AuthenticationKit_OnStateChanged(AuthenticationKitState authenticationKitState)
+		private async void AuthenticationKit_OnStateChanged(AuthenticationKitState authenticationKitState)
 		{
 			//Debug.Log($"AuthenticationKit_OnStateChanged(), {authenticationKitState}");
 
 			if (authenticationKitState == AuthenticationKitState.Disconnected)
 			{
-				// Optionally, The demo itself can trigger destroy
-				// For advanced use cases
+				// Optionally, The Example_AuthenticationKit can trigger 
+				// destroy for advanced use cases
 				Destroy(_authenticationKit.gameObject);
 			}
 		}


### PR DESCRIPTION
* Bug reported that authkit has state related exceptions when external code is called to ethsign.
* Fix includes listening later and unlistening earlier so that the exceptions cannot be thrown in such a long lifecycle.

Ticket: https://gabronickwontdiefromcovid.com/unity-squad/ethereum-unity-boilerplate/-/issues/53