### PR TITLE
chore: remove unwanted *.bak.meta files

### DIFF
--- a/Runtime/Web3Api/Interfaces/IAccountApi.cs.bak.meta
+++ b/Runtime/Web3Api/Interfaces/IAccountApi.cs.bak.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 63588f59e24d44b4fb6ee8ea8b93c43c
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Web3Api/Interfaces/INativeApi.cs.bak.meta
+++ b/Runtime/Web3Api/Interfaces/INativeApi.cs.bak.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 8f7d359a7d4f8754eb9111eb201692d1
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Web3Api/Interfaces/ITokenApi.cs.bak.meta
+++ b/Runtime/Web3Api/Interfaces/ITokenApi.cs.bak.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b61bfef82c05e384ca511a87a6527a44
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Removing the meta files just to get these warnings in unity console.

```
A meta data file (.meta) exists but its asset 'Packages/io.moralis.web3-unity-sdk/Runtime/Web3Api/Interfaces/IAccountApi.cs.bak' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
Couldn't delete Packages/io.moralis.web3-unity-sdk/Runtime/Web3Api/Interfaces/IAccountApi.cs.bak.meta because it's in an immutable folder.

A meta data file (.meta) exists but its asset 'Packages/io.moralis.web3-unity-sdk/Runtime/Web3Api/Interfaces/INativeApi.cs.bak' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
Couldn't delete Packages/io.moralis.web3-unity-sdk/Runtime/Web3Api/Interfaces/INativeApi.cs.bak.meta because it's in an immutable folder.

A meta data file (.meta) exists but its asset 'Packages/io.moralis.web3-unity-sdk/Runtime/Web3Api/Interfaces/ITokenApi.cs.bak' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
Couldn't delete Packages/io.moralis.web3-unity-sdk/Runtime/Web3Api/Interfaces/ITokenApi.cs.bak.meta because it's in an immutable folder.
```